### PR TITLE
Fixed unity crash when reading BLE data

### DIFF
--- a/BleWinrtDll/BleWinrtDll.cpp
+++ b/BleWinrtDll/BleWinrtDll.cpp
@@ -4,7 +4,6 @@
 #include "stdafx.h"
 
 #include "BleWinrtDll.h"
-//#include <coroutine>
 
 #pragma comment(lib, "windowsapp")
 
@@ -105,7 +104,6 @@ void saveError(const wchar_t* message, ...) {
 	va_start(args, message);
 	vswprintf_s(last_error, message, args);
 	va_end(args);
-	//wcout << last_error << endl;
 }
 
 IAsyncOperation<BluetoothLEDevice> retrieveDevice(wchar_t* deviceId) {
@@ -570,7 +568,7 @@ class Reading {
 	uint8_t values[512] = {};
 	uint32_t valueCount = 0;
 	uint32_t readIndex = -1;
-	BLECharacteristic characteristics;
+	BLECharacteristic characteristics = {};
 	bool done = false;
 public:
 
@@ -650,11 +648,6 @@ vector<Reading*> readings;
 
 fire_and_forget ReadDataAsync(Reading* reading) {
 	try {
-		//auto c = characteristic.CharacteristicProperties();
-		//if (((uint32_t)c & (uint32_t)GattCharacteristicProperties::Read) == 0) {
-		//	saveError(L"%s:%d Characteristic %s does not have read property!", __WFILE__, __LINE__, id->characteristicUuid);
-		//	co_return;
-		//}
 		while (reading->isReading()) {
 			auto characteristic = co_await retrieveCharacteristic(reading->getDevice(), reading->getService(), reading->getCharacteristic());
 			if (characteristic != nullptr) {
@@ -727,13 +720,13 @@ void CancelRead(BLECharacteristic* id)
 	}
 }
 
-void PollReadData(BLECharacteristic* id, uint8_t* data)
+void PollReadData(BLECharacteristic* id, uint8_t* data, uint16_t size)
 {
 	lock_guard readingsGuard(readingsLock);
 	for (auto reading : readings)
 	{
 		if (*reading == *id) {
-			reading->getData(data, 512);
+			reading->getData(data, size);
 			break;
 		}
 	}

--- a/BleWinrtDll/BleWinrtDll.h
+++ b/BleWinrtDll/BleWinrtDll.h
@@ -22,18 +22,20 @@ struct Characteristic {
 	wchar_t userDescription[100];
 };
 
+#define UUID_LENGTH 256
+
 struct BLEData {
 	uint8_t buf[512];
 	uint16_t size;
-	wchar_t deviceId[256];
-	wchar_t serviceUuid[256];
-	wchar_t characteristicUuid[256];
+	wchar_t deviceId[UUID_LENGTH];
+	wchar_t serviceUuid[UUID_LENGTH];
+	wchar_t characteristicUuid[UUID_LENGTH];
 };
 
 struct BLECharacteristic {
-	wchar_t deviceId[256];
-	wchar_t serviceUuid[256];
-	wchar_t characteristicUuid[256];
+	wchar_t deviceId[UUID_LENGTH];
+	wchar_t serviceUuid[UUID_LENGTH];
+	wchar_t characteristicUuid[UUID_LENGTH];
 };
 
 struct ErrorMessage {
@@ -64,8 +66,12 @@ extern "C" {
 
 	__declspec(dllexport) bool SendData(BLEData* data, bool block);
 
-	__declspec(dllexport) bool ReadData(BLECharacteristic* id, BLEData* data, bool block);
+	__declspec(dllexport) void ReadData(BLECharacteristic* id);
 
+	__declspec(dllexport) void StopReadData(BLECharacteristic* id);
+
+	__declspec(dllexport) void PollReadData(BLECharacteristic* id, uint8_t* data);
+	
 	__declspec(dllexport) void Quit();
 
 	__declspec(dllexport) void GetError(ErrorMessage* buf);

--- a/BleWinrtDll/BleWinrtDll.h
+++ b/BleWinrtDll/BleWinrtDll.h
@@ -70,7 +70,7 @@ extern "C" {
 
 	__declspec(dllexport) void StopReadData(BLECharacteristic* id);
 
-	__declspec(dllexport) void PollReadData(BLECharacteristic* id, uint8_t* data);
+	__declspec(dllexport) void PollReadData(BLECharacteristic* id, uint8_t* data, uint16_t size);
 	
 	__declspec(dllexport) void Quit();
 

--- a/BleWinrtDll/BleWinrtDll.h
+++ b/BleWinrtDll/BleWinrtDll.h
@@ -1,9 +1,6 @@
 #pragma once
-
 #include "stdafx.h"
-
-//Macro to determine the length of an C array
-#define ARRAY_LENGTH(a) ((sizeof((a))) / (sizeof(*(a))))
+#include "Helpers.h"
 
 struct DeviceUpdate {
 	wchar_t id[100];
@@ -21,8 +18,6 @@ struct Characteristic {
 	wchar_t uuid[100];
 	wchar_t userDescription[100];
 };
-
-#define UUID_LENGTH 256
 
 struct BLEData {
 	uint8_t buf[512];

--- a/BleWinrtDll/BleWinrtDll.vcxproj
+++ b/BleWinrtDll/BleWinrtDll.vcxproj
@@ -169,13 +169,41 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClInclude Include="BleWinrtDll.h" />
+    <ClInclude Include="deviceCaching.h" />
+    <ClInclude Include="helpers.h" />
+    <ClInclude Include="logging.h" />
+    <ClInclude Include="reading.h" />
     <ClInclude Include="resource.h" />
     <ClInclude Include="stdafx.h" />
     <ClInclude Include="targetver.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="BleWinrtDll.cpp" />
+    <ClCompile Include="deviceCaching.cpp">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
     <ClCompile Include="dllmain.cpp" />
+    <ClCompile Include="helpers.cpp">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="logging.cpp">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="reading.cpp">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
     <ClCompile Include="stdafx.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>

--- a/BleWinrtDll/BleWinrtDll.vcxproj.filters
+++ b/BleWinrtDll/BleWinrtDll.vcxproj.filters
@@ -27,6 +27,18 @@
     <ClInclude Include="resource.h">
       <Filter>Headerdateien</Filter>
     </ClInclude>
+    <ClInclude Include="reading.h">
+      <Filter>Headerdateien</Filter>
+    </ClInclude>
+    <ClInclude Include="helpers.h">
+      <Filter>Headerdateien</Filter>
+    </ClInclude>
+    <ClInclude Include="deviceCaching.h">
+      <Filter>Headerdateien</Filter>
+    </ClInclude>
+    <ClInclude Include="logging.h">
+      <Filter>Headerdateien</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="stdafx.cpp">
@@ -36,6 +48,18 @@
       <Filter>Quelldateien</Filter>
     </ClCompile>
     <ClCompile Include="dllmain.cpp">
+      <Filter>Quelldateien</Filter>
+    </ClCompile>
+    <ClCompile Include="helpers.cpp">
+      <Filter>Quelldateien</Filter>
+    </ClCompile>
+    <ClCompile Include="deviceCaching.cpp">
+      <Filter>Quelldateien</Filter>
+    </ClCompile>
+    <ClCompile Include="logging.cpp">
+      <Filter>Quelldateien</Filter>
+    </ClCompile>
+    <ClCompile Include="reading.cpp">
       <Filter>Quelldateien</Filter>
     </ClCompile>
   </ItemGroup>

--- a/BleWinrtDll/deviceCaching.cpp
+++ b/BleWinrtDll/deviceCaching.cpp
@@ -1,0 +1,66 @@
+#include "DeviceCaching.h"
+#include "Logging.h"
+#include "Helpers.h"
+#define __WFILE__ L"DeviceCaching.cpp"
+
+map<long, DeviceCacheEntry> cache;
+
+IAsyncOperation<BluetoothLEDevice> retrieveDevice(wchar_t* deviceId) {
+	if (cache.count(hsh(deviceId)))
+		co_return cache[hsh(deviceId)].device;
+	// !!!! BluetoothLEDevice.FromIdAsync may prompt for consent, in this case bluetooth will fail in unity!
+	BluetoothLEDevice result = co_await BluetoothLEDevice::FromIdAsync(deviceId);
+	if (result == nullptr) {
+		saveError(L"%s:%d Failed to connect to device.", __WFILE__, __LINE__);
+		co_return nullptr;
+	}
+	else {
+		clearError();
+		cache[hsh(deviceId)] = { result };
+		co_return cache[hsh(deviceId)].device;
+	}
+}
+
+IAsyncOperation<GattDeviceService> retrieveService(wchar_t* deviceId, wchar_t* serviceId) {
+	auto device = co_await retrieveDevice(deviceId);
+	if (device == nullptr)
+		co_return nullptr;
+	if (cache[hsh(deviceId)].services.count(hsh(serviceId)))
+		co_return cache[hsh(deviceId)].services[hsh(serviceId)].service;
+	GattDeviceServicesResult result = co_await device.GetGattServicesForUuidAsync(make_guid(serviceId), BluetoothCacheMode::Cached);
+	if (result.Status() != GattCommunicationStatus::Success) {
+		saveError(L"%s:%d Failed retrieving services.", __WFILE__, __LINE__);
+		co_return nullptr;
+	}
+	else if (result.Services().Size() == 0) {
+		saveError(L"%s:%d No service found with uuid ", __WFILE__, __LINE__);
+		co_return nullptr;
+	}
+	else {
+		clearError();
+		cache[hsh(deviceId)].services[hsh(serviceId)] = { result.Services().GetAt(0) };
+		co_return cache[hsh(deviceId)].services[hsh(serviceId)].service;
+	}
+}
+
+IAsyncOperation<GattCharacteristic> retrieveCharacteristic(wchar_t* deviceId, wchar_t* serviceId, wchar_t* characteristicId) {
+	auto service = co_await retrieveService(deviceId, serviceId);
+	if (service == nullptr)
+		co_return nullptr;
+	if (cache[hsh(deviceId)].services[hsh(serviceId)].characteristics.count(hsh(characteristicId)))
+		co_return cache[hsh(deviceId)].services[hsh(serviceId)].characteristics[hsh(characteristicId)].characteristic;
+	GattCharacteristicsResult result = co_await service.GetCharacteristicsForUuidAsync(make_guid(characteristicId), BluetoothCacheMode::Cached);
+	if (result.Status() != GattCommunicationStatus::Success) {
+		saveError(L"%s:%d Error scanning characteristics from service %s with status %d", __WFILE__, __LINE__, serviceId, result.Status());
+		co_return nullptr;
+	}
+	else if (result.Characteristics().Size() == 0) {
+		saveError(L"%s:%d No characteristic found with uuid %s", __WFILE__, __LINE__, characteristicId);
+		co_return nullptr;
+	}
+	else {
+		clearError();
+		cache[hsh(deviceId)].services[hsh(serviceId)].characteristics[hsh(characteristicId)] = { result.Characteristics().GetAt(0) };
+		co_return cache[hsh(deviceId)].services[hsh(serviceId)].characteristics[hsh(characteristicId)].characteristic;
+	}
+}

--- a/BleWinrtDll/deviceCaching.h
+++ b/BleWinrtDll/deviceCaching.h
@@ -1,0 +1,29 @@
+#pragma once
+#include "stdafx.h"
+
+using namespace winrt::Windows::Devices::Bluetooth::GenericAttributeProfile;
+using namespace winrt::Windows::Devices::Bluetooth;
+using namespace std;
+
+using namespace winrt::Windows::Foundation;
+
+// implement own caching instead of using the system-provicded cache as there is an AccessDenied error when trying to
+// call GetCharacteristicsAsync on a service for which a reference is hold in global scope
+// cf. https://stackoverflow.com/a/36106137
+struct CharacteristicCacheEntry {
+	GattCharacteristic characteristic = nullptr;
+};
+struct ServiceCacheEntry {
+	GattDeviceService service = nullptr;
+	map<long, CharacteristicCacheEntry> characteristics = { };
+};
+struct DeviceCacheEntry {
+	BluetoothLEDevice device = nullptr;
+	map<long, ServiceCacheEntry> services = { };
+};
+
+extern map<long, DeviceCacheEntry> cache;
+
+IAsyncOperation<BluetoothLEDevice> retrieveDevice(wchar_t* deviceId);
+IAsyncOperation<GattDeviceService> retrieveService(wchar_t* deviceId, wchar_t* serviceId);
+IAsyncOperation<GattCharacteristic> retrieveCharacteristic(wchar_t* deviceId, wchar_t* serviceId, wchar_t* characteristicId);

--- a/BleWinrtDll/helpers.cpp
+++ b/BleWinrtDll/helpers.cpp
@@ -1,0 +1,59 @@
+#include "Helpers.h"
+
+long hsh(wchar_t* wstr)
+{
+	long hash = 5381;
+	int c;
+	while (c = *wstr++)
+		hash = ((hash << 5) + hash) + c;
+	return hash;
+}
+
+const uint8_t BYTE_ORDER[] = { 3, 2, 1, 0, 5, 4, 7, 6, 8, 9, 10, 11, 12, 13, 14, 15 };
+guid make_guid(const wchar_t* value)
+{
+	to_guid to_guid;
+	memset(&to_guid, 0, sizeof(to_guid));
+	int offset = 0;
+	for (int i = 0; i < wcslen(value); i++) {
+		if (value[i] >= '0' && value[i] <= '9')
+		{
+			uint8_t digit = value[i] - '0';
+			to_guid.buf[BYTE_ORDER[offset / 2]] += offset % 2 == 0 ? digit << 4 : digit;
+			offset++;
+		}
+		else if (value[i] >= 'A' && value[i] <= 'F')
+		{
+			uint8_t digit = 10 + value[i] - 'A';
+			to_guid.buf[BYTE_ORDER[offset / 2]] += offset % 2 == 0 ? digit << 4 : digit;
+			offset++;
+		}
+		else if (value[i] >= 'a' && value[i] <= 'f')
+		{
+			uint8_t digit = 10 + value[i] - 'a';
+			to_guid.buf[BYTE_ORDER[offset / 2]] += offset % 2 == 0 ? digit << 4 : digit;
+			offset++;
+		}
+		else
+		{
+			// skip char
+		}
+	}
+	return to_guid.guid;
+}
+
+
+// global flag to release calling thread
+mutex quitLock;
+bool quitFlag = false;
+
+bool QuittableWait(condition_variable& signal, unique_lock<mutex>& waitLock) {
+	{
+		lock_guard quit_lock(quitLock);
+		if (quitFlag)
+			return true;
+	}
+	signal.wait(waitLock);
+	lock_guard quit_lock(quitLock);
+	return quitFlag;
+}

--- a/BleWinrtDll/helpers.h
+++ b/BleWinrtDll/helpers.h
@@ -1,0 +1,30 @@
+#pragma once
+#include "stdafx.h"
+
+using std::condition_variable;
+using std::unique_lock;
+using std::lock_guard;
+using std::mutex;
+
+using winrt::guid;
+
+//Macro to determine the length of an C array
+#define ARRAY_LENGTH(a) ((sizeof((a))) / (sizeof(*(a))))
+#define UUID_LENGTH 256
+
+extern mutex quitLock;
+extern bool quitFlag;
+
+union to_guid
+{
+	uint8_t buf[16];
+	guid guid;
+};
+
+guid make_guid(const wchar_t* value);
+
+// using hashes of uuids to omit storing the c-strings in reliable storage
+long hsh(wchar_t* wstr);
+
+
+bool QuittableWait(condition_variable& signal, unique_lock<mutex>& waitLock);

--- a/BleWinrtDll/logging.cpp
+++ b/BleWinrtDll/logging.cpp
@@ -1,0 +1,27 @@
+#include "Logging.h"
+#include "BleWinrtDll.h"
+
+using std::mutex;
+using std::lock_guard;
+
+mutex errorLock;
+wchar_t last_error[2048];
+
+void clearError() {
+	lock_guard error_lock(errorLock);
+	wcscpy_s(last_error, L"Ok");
+}
+
+void saveError(const wchar_t* message, ...) {
+	lock_guard error_lock(errorLock);
+	va_list args;
+	va_start(args, message);
+	vswprintf_s(last_error, message, args);
+	va_end(args);
+}
+
+//Exported function: Definition in BleWinrtDll.h
+void GetError(ErrorMessage* buf) {
+	lock_guard error_lock(errorLock);
+	wcscpy_s(buf->msg, last_error);
+}

--- a/BleWinrtDll/logging.h
+++ b/BleWinrtDll/logging.h
@@ -1,0 +1,4 @@
+#pragma once
+
+void clearError();
+void saveError(const wchar_t* message, ...);

--- a/BleWinrtDll/reading.cpp
+++ b/BleWinrtDll/reading.cpp
@@ -1,0 +1,68 @@
+#include "Reading.h"
+
+
+void Reading::waitDone() {
+	unique_lock valuesLock(valuesMutex);
+	doneSignal.wait(valuesLock, [&] { return done; });
+}
+
+void Reading::finish()
+{
+	done = true;
+	doneSignal.notify_one();
+}
+
+bool Reading::operator<(Reading& other) {
+	int val = wcscmp(this->characteristics.deviceId, other.characteristics.deviceId);
+	if (val != 0) return val < 0;
+	val = wcscmp(this->characteristics.serviceUuid, other.characteristics.serviceUuid);
+	if (val != 0) return val < 0;
+	val = wcscmp(this->characteristics.characteristicUuid, other.characteristics.characteristicUuid);
+	return val < 0;
+}
+
+bool Reading::operator==(Reading& other) {
+	return *this == other.characteristics;
+}
+
+bool Reading::operator==(BLECharacteristic& other) {
+	return (
+		(wcscmp(this->characteristics.characteristicUuid, other.characteristicUuid) == 0) &&
+		(wcscmp(this->characteristics.serviceUuid, other.serviceUuid) == 0) &&
+		(wcscmp(this->characteristics.deviceId, other.deviceId) == 0));
+}
+
+void Reading::reuseRead() {
+	lock_guard readingLock(readingMutex);
+	this->reading = true;
+}
+
+bool Reading::isReading() {
+	lock_guard readingLock(readingMutex);
+	return this->reading;
+}
+
+void Reading::stopReading(bool lock)
+{
+	if (lock) {
+		unique_lock readingLock(readingMutex);
+	}
+	else {
+		lock_guard readingLock(readingMutex);
+		this->reading = false;
+	}
+}
+
+void Reading::setData(uint8_t* data, uint32_t len) {
+	lock_guard lock(valuesMutex);
+	uint64_t l = min(len, sizeof(values));
+	memcpy(values, data, l);
+	++readIndex;
+}
+
+void Reading::getData(uint8_t* data, uint32_t len)
+{
+	lock_guard lock(valuesMutex);
+	uint64_t l = min(len, sizeof(values));
+	memcpy(data, values, l);
+}

--- a/BleWinrtDll/reading.h
+++ b/BleWinrtDll/reading.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include "stdafx.h"
+#include "BleWinrtDll.h"
+
+using namespace std;
+
+using namespace winrt;
+using namespace Windows::Foundation;
+using namespace Windows::Foundation::Collections;
+using namespace Windows::Web::Syndication;
+
+using namespace Windows::Devices::Bluetooth;
+using namespace Windows::Devices::Bluetooth::GenericAttributeProfile;
+using namespace Windows::Devices::Enumeration;
+
+using namespace Windows::Storage::Streams;
+
+//Internal class for handling a coroutine constantly Reading data from characteristic
+//Thread safe?
+class Reading {
+	bool reading = true;
+	mutex readingMutex;
+
+	mutex valuesMutex;
+	condition_variable doneSignal;
+	uint8_t values[512] = {};
+	uint32_t valueCount = 0;
+	uint32_t readIndex = -1;
+	BLECharacteristic characteristics = {};
+	bool done = false;
+
+public:
+	wchar_t* getDevice() { return this->characteristics.deviceId; }
+	wchar_t* getService() { return this->characteristics.serviceUuid; }
+	wchar_t* getCharacteristic() { return this->characteristics.characteristicUuid; }
+
+	bool operator<(Reading& other);
+	bool operator==(Reading& other);
+	bool operator==(BLECharacteristic& other);
+
+	void waitDone();
+	void finish();
+	void reuseRead();
+	bool isReading();
+	void stopReading(bool lock = false);
+	void setData(uint8_t* data, uint32_t len);
+	void getData(uint8_t* data, uint32_t len);
+
+};

--- a/DebugBle/BLE.cs
+++ b/DebugBle/BLE.cs
@@ -112,7 +112,7 @@ public class BLE
         public static extern void StopReadData(in BLECharacteristic id);
 
         [DllImport(DLL_NAME, EntryPoint = "PollReadData")]
-        public static extern void PollReadData(in BLECharacteristic id, [In, Out] byte[] data);
+        public static extern void PollReadData(in BLECharacteristic id, [In, Out] byte[] data, ushort size);
 
         [DllImport(DLL_NAME, EntryPoint = "Quit")]
         public static extern void Quit();

--- a/DebugBle/BLE.cs
+++ b/DebugBle/BLE.cs
@@ -14,7 +14,7 @@ public class BLE
         "BleWinrtDll.dll";
 #endif
     // dll calls
-    class Impl
+    public class Impl
     {
         public enum ScanStatus { PROCESSING, AVAILABLE, FINISHED };
 
@@ -78,8 +78,8 @@ public class BLE
         {
             [MarshalAs(UnmanagedType.ByValArray, SizeConst = 512)]
             public byte[] buf;
-            [MarshalAs(UnmanagedType.I2)]
-            public short size;
+            [MarshalAs(UnmanagedType.U2)]
+            public ushort size;
             [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 256)]
             public string deviceId;
             [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 256)]
@@ -106,7 +106,13 @@ public class BLE
         };
 
         [DllImport(DLL_NAME, EntryPoint = "ReadData")]
-        public static extern bool ReadData(in BLECharacteristic id, out BLEData dataOut, bool block);
+        public static extern void ReadData(in BLECharacteristic id);
+
+        [DllImport(DLL_NAME, EntryPoint = "StopReadData")]
+        public static extern void StopReadData(in BLECharacteristic id);
+
+        [DllImport(DLL_NAME, EntryPoint = "PollReadData")]
+        public static extern void PollReadData(in BLECharacteristic id, [In, Out] byte[] data);
 
         [DllImport(DLL_NAME, EntryPoint = "Quit")]
         public static extern void Quit();
@@ -185,37 +191,9 @@ public class BLE
         return currentScan;
     }
 
-    public static Dictionary<string, ushort> ReadData(string deviceId, Dictionary<string, Dictionary<string, string>> profile)
+    public static void ReadData(Impl.BLECharacteristic characteristic)
     {
-        Dictionary<string, ushort> ret = new Dictionary<string, ushort>();
-        foreach (var service in profile)
-        {
-            foreach (var characteristics in service.Value)
-            {
-                Impl.BLECharacteristic characteristic = new Impl.BLECharacteristic
-                {
-                    deviceId = deviceId,
-                    serviceUuid = service.Key,
-                    characteristicUuid = characteristics.Key
-                };
-                Impl.BLEData data = new Impl.BLEData
-                {
-                    buf = new byte[512]
-                };
-                data.buf[0] = 1;
-                bool gotData = Impl.ReadData(characteristic, out data, true);
-                if (gotData)
-                {
-                    if (data.size > 0)
-                    {
-                        Debug.Log(data.size);
-                        //Debug.Log(data.buf);
-                    }
-                    ret.Add(characteristics.Key, (ushort)(data.buf[0] + (data.buf[1] << 8)));
-                }
-            }
-        }
-        return ret;
+        Impl.ReadData(characteristic);
     }
 
     public static void RetrieveProfile(string deviceId, string serviceUuid)
@@ -280,20 +258,23 @@ public class BLE
         } while (status != Impl.ScanStatus.FINISHED);
         // wait some delay to prevent error
         Thread.Sleep(200);
+        Debug.Log("Scanning for characteristics");
         Impl.Characteristic c = new Impl.Characteristic();
         foreach (var s in device)
         {
             Impl.ScanCharacteristics(deviceId, s.Key);
             do {
-                status = Impl.PollCharacteristic(out c, false);
+                status = Impl.PollCharacteristic(out c, true);
                 if (status == Impl.ScanStatus.AVAILABLE)
                 {
+                    Debug.Log(GetError());
                     Debug.Log("characteristic found: " + c.uuid + ", user description: " + c.userDescription);
                     if (!s.Value.ContainsKey(c.uuid))
                     {
                         s.Value.Add(c.uuid, c.userDescription);
                     }
                 }
+                Thread.Sleep(30);
             } while (status != Impl.ScanStatus.FINISHED);
         }
         return device;
@@ -303,7 +284,7 @@ public class BLE
     {
         Impl.BLEData packageSend;
         packageSend.buf = new byte[512];
-        packageSend.size = (short)data.Length;
+        packageSend.size = (ushort)data.Length;
         packageSend.deviceId = deviceId;
         packageSend.serviceUuid = serviceUuid;
         packageSend.characteristicUuid = characteristicUuid;

--- a/DebugBle/DebugBle.csproj
+++ b/DebugBle/DebugBle.csproj
@@ -12,6 +12,21 @@
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Deterministic>true</Deterministic>
+    <PublishUrl>publish\</PublishUrl>
+    <Install>true</Install>
+    <InstallFrom>Disk</InstallFrom>
+    <UpdateEnabled>false</UpdateEnabled>
+    <UpdateMode>Foreground</UpdateMode>
+    <UpdateInterval>7</UpdateInterval>
+    <UpdateIntervalUnits>Days</UpdateIntervalUnits>
+    <UpdatePeriodically>false</UpdatePeriodically>
+    <UpdateRequired>false</UpdateRequired>
+    <MapFileExtensions>true</MapFileExtensions>
+    <ApplicationRevision>0</ApplicationRevision>
+    <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
+    <IsWebBootstrapper>false</IsWebBootstrapper>
+    <UseApplicationTrust>false</UseApplicationTrust>
+    <BootstrapperEnabled>true</BootstrapperEnabled>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>x64</PlatformTarget>
@@ -53,10 +68,16 @@
     <None Include="App.config" />
   </ItemGroup>
   <ItemGroup>
-    <Content Include="BleWinrtDll.dll">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="BleWinrtDllDebug.dll" />
+    <BootstrapperPackage Include=".NETFramework,Version=v4.7.2">
+      <Visible>False</Visible>
+      <ProductName>Microsoft .NET Framework 4.7.2 %28x86 and x64%29</ProductName>
+      <Install>true</Install>
+    </BootstrapperPackage>
+    <BootstrapperPackage Include="Microsoft.Net.Framework.3.5.SP1">
+      <Visible>False</Visible>
+      <ProductName>.NET Framework 3.5 SP1</ProductName>
+      <Install>false</Install>
+    </BootstrapperPackage>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/DebugBle/DebugBle.csproj.user
+++ b/DebugBle/DebugBle.csproj.user
@@ -1,6 +1,18 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <ProjectView>ShowAllFiles</ProjectView>
+    <ProjectView>ProjectFiles</ProjectView>
+    <PublishUrlHistory>publish\</PublishUrlHistory>
+    <InstallUrlHistory />
+    <SupportUrlHistory />
+    <UpdateUrlHistory />
+    <BootstrapperUrlHistory />
+    <ErrorReportUrlHistory />
+    <FallbackCulture>en-US</FallbackCulture>
+    <VerifyUploadedFiles>false</VerifyUploadedFiles>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
+    <StartAction>Project</StartAction>
+    <EnableUnmanagedDebugging>true</EnableUnmanagedDebugging>
   </PropertyGroup>
 </Project>

--- a/DebugBle/Program.cs
+++ b/DebugBle/Program.cs
@@ -75,7 +75,7 @@ namespace DebugBle
                 while (!done)
                 {
                     byte[] data = new byte[512];
-                    BLE.Impl.PollReadData(characteristic, data);
+                    BLE.Impl.PollReadData(characteristic, data, (ushort)data.Length);
                     if(data != null)
                         Console.WriteLine("[{0}]", string.Join(", ", data));
                     if (i >= 100) done = true;

--- a/DebugBle/Program.cs
+++ b/DebugBle/Program.cs
@@ -21,7 +21,9 @@ namespace DebugBle
             {
                 Console.WriteLine("found device with name: " + deviceName);
                 if (deviceId == null && deviceName == "D_Glove_IMU_L_F")
+                {
                     deviceId = _deviceId;
+                }
             };
             scan.Finished = () =>
             {
@@ -43,32 +45,46 @@ namespace DebugBle
 
             var profile = BLE.GetProfile(deviceId);
 
-            foreach(var service in profile)
+            BLE.Impl.BLECharacteristic characteristic = new BLE.Impl.BLECharacteristic();
+
+            foreach (var service in profile)
             {
                 Console.WriteLine("Service: " + service.Key);
                 foreach(var characteristics in service.Value)
                 {
                     Console.WriteLine("Characteristics: " + characteristics.Key + " " + characteristics.Value);
-                }
-            }
-
-
-            bool done = false;
-            while (!done)
-            {
-                var data = BLE.ReadData(deviceId, profile);
-                foreach (var dat in data)
-                {
-                    if (dat.Value != 0)
+                    if (characteristics.Key.StartsWith("{f9dcb357-be34-4c6f-9017-dd5e0bdd7b20}"))
                     {
-                        done = true;
-                        break;
+                        characteristic.deviceId = deviceId;
+                        characteristic.serviceUuid = service.Key;
+                        characteristic.characteristicUuid = characteristics.Key;
                     }
                 }
             }
 
+            if (string.IsNullOrEmpty(characteristic.characteristicUuid))
+            {
+                Console.WriteLine("Could not find the requested characteristic!");
+            }
+            else
+            {
+                BLE.ReadData(characteristic);
+
+                bool done = false;
+                UInt32 i = 0;
+                while (!done)
+                {
+                    byte[] data = new byte[512];
+                    BLE.Impl.PollReadData(characteristic, data);
+                    if(data != null)
+                        Console.WriteLine("[{0}]", string.Join(", ", data));
+                    if (i >= 100) done = true;
+                    ++i;
+                }
+            }
             Console.WriteLine("Press enter to exit the program...");
             Console.ReadLine();
+            BLE.Impl.Quit();
         }
     }
 }


### PR DESCRIPTION
## Description

Fixed BLE read data method that was never returning when running in Unity. Created a coroutine in C++ that constantly retrieves and stores characteristic values. This data can then be polled on request using a separate method. C# test project updated to reflect the changes.

Closes #5 

## Checklist for Author

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have tested/added tests to validate my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Checklist for Reviewers

- [ ] Code follows the project style guidelines
- [ ] Code is self-documenting and well-commented
- [ ] All tests pass locally and on CI
- [ ] Related issue is referenced and closed as appropriate
- [ ] Documentation has been updated if necessary
- [ ] Changes are justified and necessary
- [ ] Code changes are covered by tests
- [ ] No new security vulnerabilities are introduced

## Additional Notes

Please add any additional notes for the reviewers here.
